### PR TITLE
resolve error of creating lib folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ node_js:
   - '7'
 addons: 
   firefox: "43.0"
+before_install:
+  - npm install -g bower
+  - bower install
 install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "yargs": "^4.3.1"
   },
   "scripts": {
+    "postinstall": "./node_modules/.bin/bower install",
     "clean": "rimraf dist && rimraf coverage*",
     "build": "npm run clean && webpack --progress --colors --mode=production --target=web",
     "build:dev": "npm run clean && webpack --progress --colors --mode=dev --target=web",


### PR DESCRIPTION
ISSUE NUMBER - [01 ](https://github.com/JudeNiroshan/openmrs-owa-built-in-reports/issues/1)

SUMMARY 
error - when running "npm run build:prod" or "npm run build:deploy" UI libraries are not created in the code base.
Solution - add "bower install" command inside the package.json file. 