### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist
 config.json
 libs
 .vscode
+.idea
+**/*.zip
+npm-debug.log


### PR DESCRIPTION
To prevent accidentally adding zip files and IDE-specific settings.