### PR TITLE
Issue-11 Added version tag to the Browser router baseName

### DIFF
--- a/app/js/openmrs-owa-built-in-reports.jsx
+++ b/app/js/openmrs-owa-built-in-reports.jsx
@@ -15,8 +15,9 @@ import {Router, Route, hashHistory, BrowserRouter} from 'react-router-dom'
 
 import routes from './routes'
 
+var packageJson = require("../manifest.webapp");
 render((
-         <BrowserRouter basename="/openmrs/owa/openmrs-owa-built-in-reports" history={hashHistory}>
+         <BrowserRouter basename={"/openmrs/owa/openmrs-owa-built-in-reports-" + packageJson.version} history={hashHistory}>
            {routes()}
          </BrowserRouter>
        ), document.getElementById('app'));

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "regenerator-runtime": "^0.10.5",
     "rimraf": "^2.5.2",
     "sinon": "^2.4.1",
+    "json-loader": "^0.5.4",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.13",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -177,7 +177,10 @@ var webpackConfig = {
 	}, {
 	    test: /\.html$/,
 	    loader: 'html'
-	}],
+	}, {
+		test: /\.(json|webapp)$/,
+		loader: 'json-loader'
+  }],
   },
   resolve: {
     root: path.resolve('./src'),


### PR DESCRIPTION
Issue : #11 

BrowserRouter basesName is fixed to static address `/openmrs/owa/openmrs-owa-built-in-reports`. Currently Open Web Apps module is serving the OWA URLs with the respected version tags. So it should be like `/openmrs/owa/openmrs-owa-built-in-reports-0.9.4`.

It would be better to fetch the version tag from the `manifest.webapp` file since we can't provide a static version tag into the baseName. So I have changed the code to fetch the version tag from the `manifest.webapp` file.

![image](https://user-images.githubusercontent.com/30535710/37751860-cbdd06d8-2dba-11e8-8673-def3eb16d81d.png)
