### PR TITLE
Issue-13 Added Header components hyperlinks to load the respected pages

### DIFF
--- a/app/js/components/common/Header.jsx
+++ b/app/js/components/common/Header.jsx
@@ -89,7 +89,7 @@ export class Header extends Component {
                             </a>
                             <ul className="dropdown-menu user">
                                 <li>
-                                    <a href="#">My Account</a>
+                                    <a href="/openmrs/adminui/myaccount/myAccount.page">My Account</a>
                                 </li>
                             </ul>
                         </li>
@@ -112,7 +112,7 @@ export class Header extends Component {
 
                     <NavLink to="" activeClassName="active">
                         <li>
-                            <a href="#">Logout {' '}
+                            <a href="/openmrs/appui/header/logout.action?successUrl=openmrs">Logout {' '}
                                 <span className="glyphicon glyphicon-log-out"/></a>
                         </li>
                     </NavLink>


### PR DESCRIPTION
Issue : #13 
Header components such as MyAccount and Logout sections didn't load the respected pages as we expected. Actually those are not configured to load the respected pages.

I have added the required hyperlinks to load those pages when the user clicks on that. 
After the modifications, it worked for me without any issues.