### PR TITLE
Modify the height of the menu items nav-bar.

### DIFF
--- a/app/js/components/common/ReportNavMenu.css
+++ b/app/js/components/common/ReportNavMenu.css
@@ -2,7 +2,7 @@
 
 .navWrapper {
     width: 100%;
-    height: 500px;
+    height: auto;
     position: relative;
     background: #3f3d74;
     font-family: 'Quicksand', sans-serif;


### PR DESCRIPTION
ISSUE NUMBER - [15](https://github.com/JudeNiroshan/openmrs-owa-built-in-reports/issues/15)

SUMMARY
changed the height of menu-items nav-bar to **auto** inside the[ CSS](https://github.com/JudeNiroshan/openmrs-owa-built-in-reports/blob/master/app/js/components/common/ReportNavMenu.css#L5) file.

![image](https://user-images.githubusercontent.com/18748482/37785762-0100c578-2e21-11e8-9cf7-8a1530b9292c.png)
